### PR TITLE
Fix MsgReader::read_to_end()

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -111,6 +111,7 @@ impl<'a> MsgReader<'a> {
     /// Reads all remaining bytes.
     pub fn read_to_end(&mut self) -> Result<Vec<u8>, DecodeError> {
         let mut res = Vec::with_capacity(self.remaining());
+        res.resize(self.remaining(), 0);
         try!(self.read(&mut res));
         Ok(res)
     }


### PR DESCRIPTION
The buffer was initialized as a new empty vector with a certain capacity. But while the capacity is set to the number of remaining bytes, the length will remain at 0.

As a quickfix, this commit resizes the vector to match the capacity.

It's probably cleaner though to pass a length integer to `MsgReader::read`. What do you think, @murarth?

This fixes TXT lookup.
