### PR TITLE
Remove #![feature(time2)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 //! Domain Name System (DNS) communication protocol.
 
-#![feature(time2)]
 #![deny(missing_docs)]
 
 extern crate libc;


### PR DESCRIPTION
It's not necessary anymore on nightly and it causes compilation on Beta (1.8) to fail.

The warnings on stable aren't a problem, as 1.8 will be released in 9 days and it doesn't compile with the feature flag either.
