### PR TITLE
Return an error in default_config on Windows

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,6 @@ fn default_config_impl() -> io::Result<DnsConfig> {
 #[cfg(windows)]
 fn default_config_impl() -> io::Result<DnsConfig> {
     // TODO: Get a list of nameservers from Windows API.
-    // For now, generate a compile error.
-    nameserver_list_not_available_on_windows()
+    // For now, return an IO error.
+    Err(io::Error::new(io::ErrorKind::Other, "Nameserver list not available on Windows"))
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -548,7 +548,7 @@ impl<'a> MsgWriter<'a> {
         rd.r_type = resource.r_type.to_u16().to_be();
         rd.r_class = resource.r_class.to_u16().to_be();
         rd.ttl = resource.ttl.to_be();
-        rd.length = try!(to_u16(rdata.len()));
+        rd.length = try!(to_u16(rdata.len())).to_be();
 
         let buf: [u8; 10] = unsafe { transmute(rd) };
 


### PR DESCRIPTION
This compile error makes the library unusable on Windows, even in use cases where default_config is not needed.
