### PR TITLE
Update dependencies and clear some compiler warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ authors = ["Murarth <murarth@gmail.com>"]
 idna = "0.1"
 libc = "0.2"
 log = "0.4"
-rand = "0.3"
+rand = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ authors = ["Murarth <murarth@gmail.com>"]
 [dependencies]
 idna = "0.1"
 libc = "0.2"
-log = "0.3"
+log = "0.4"
 rand = "0.3"

--- a/src/idna.rs
+++ b/src/idna.rs
@@ -1,8 +1,6 @@
 //! Implements RFC 3490, Internationalized Domain Names in Applications,
 //! encoding for domain name labels containing Unicode.
 
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
 use std::borrow::Cow::{self, Borrowed, Owned};
 
 use external_idna;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,5 @@
 //! Utilities for composing, decoding, and encoding messages.
 
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
 use std::borrow::Cow::{self, Borrowed, Owned};
 use std::cell::Cell;
 use std::default::Default;


### PR DESCRIPTION
This updates two dependencies (log and rand), and removes two use statements to eliminate some compiler warnings about AsciiExt