### PR TITLE
Add config in resolver to retry on error.

### DIFF
--- a/examples/lookup_addr.rs
+++ b/examples/lookup_addr.rs
@@ -25,7 +25,7 @@ fn main() {
             Ok(name) => {
                 println!("{} resolved to \"{}\"", ip, name);
             }
-            Err(e) => println!("failed to resolve {}: {}", ip, e)
+            Err(e) => println!("failed to resolve {}: {}", ip, e),
         }
     }
 }

--- a/examples/lookup_host.rs
+++ b/examples/lookup_host.rs
@@ -24,7 +24,7 @@ fn main() {
                     println!("\"{}\" resolved to {} ({} more)", arg, addr, n);
                 }
             }
-            Err(e) => println!("failed to resolve \"{}\": {}", arg, e)
+            Err(e) => println!("failed to resolve \"{}\": {}", arg, e),
         }
     }
 }

--- a/examples/lookup_srv.rs
+++ b/examples/lookup_srv.rs
@@ -2,8 +2,8 @@ extern crate resolve;
 
 use std::env::args;
 
-use resolve::{DnsConfig, DnsResolver};
 use resolve::record::Srv;
+use resolve::{DnsConfig, DnsResolver};
 
 fn main() {
     let args = args().collect::<Vec<_>>();
@@ -35,8 +35,10 @@ fn main() {
     match resolver.resolve_record::<Srv>(&name) {
         Ok(records) => {
             for srv in records {
-                println!("SRV priority={} weight={} port={} target={}",
-                    srv.priority, srv.weight, srv.port, srv.target);
+                println!(
+                    "SRV priority={} weight={} port={} target={}",
+                    srv.priority, srv.weight, srv.port, srv.target
+                );
             }
         }
         Err(e) => {

--- a/examples/lookup_txt.rs
+++ b/examples/lookup_txt.rs
@@ -1,10 +1,10 @@
 extern crate resolve;
 
-use std::str;
 use std::env::args;
+use std::str;
 
-use resolve::{DnsConfig, DnsResolver};
 use resolve::record::Txt;
+use resolve::{DnsConfig, DnsResolver};
 
 fn main() {
     let args = args().collect::<Vec<_>>();

--- a/examples/resolver.rs
+++ b/examples/resolver.rs
@@ -40,7 +40,7 @@ fn main() {
                     println!("\"{}\" resolved to {} ({} more)", arg, addr, n);
                 }
             }
-            Err(e) => println!("failed to resolve \"{}\": {}", arg, e)
+            Err(e) => println!("failed to resolve \"{}\": {}", arg, e),
         }
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -9,12 +9,10 @@ pub fn address_equal(a: &IpAddr, b: &IpAddr) -> bool {
         (IpAddr::V4(ref a), IpAddr::V4(ref b)) => a == b,
         (IpAddr::V6(ref a), IpAddr::V6(ref b)) => a == b,
         // Not-so-simple comparison; V4 == maybe-V6-wrapped-V4
-        (IpAddr::V6(ref a), IpAddr::V4(ref b)) => {
-            match a.to_ipv4() {
-                Some(ref a4) => a4 == b,
-                None => false
-            }
-        }
+        (IpAddr::V6(ref a), IpAddr::V4(ref b)) => match a.to_ipv4() {
+            Some(ref a4) => a4 == b,
+            None => false,
+        },
         (IpAddr::V4(..), IpAddr::V6(..)) => address_equal(b, a),
     }
 }
@@ -29,8 +27,10 @@ pub fn address_name(addr: &IpAddr) -> String {
     match *addr {
         IpAddr::V4(ref addr) => {
             let octets = addr.octets();
-            format!("{}.{}.{}.{}.in-addr.arpa",
-                octets[3], octets[2], octets[1], octets[0])
+            format!(
+                "{}.{}.{}.{}.in-addr.arpa",
+                octets[3], octets[2], octets[1], octets[0]
+            )
         }
         IpAddr::V6(ref addr) => {
             let s = addr.segments();
@@ -39,22 +39,47 @@ pub fn address_name(addr: &IpAddr) -> String {
                  {:x}.{:x}.{:x}.{:x}.{:x}.{:x}.{:x}.{:x}.\
                  {:x}.{:x}.{:x}.{:x}.{:x}.{:x}.{:x}.{:x}.\
                  {:x}.{:x}.{:x}.{:x}.{:x}.{:x}.{:x}.{:x}.ip6.arpa",
-                s[7] & 0xf, (s[7] & 0x00f0) >> 4, (s[7] & 0x0f00) >> 8, (s[7] & 0xf000) >> 12,
-                s[6] & 0xf, (s[6] & 0x00f0) >> 4, (s[6] & 0x0f00) >> 8, (s[6] & 0xf000) >> 12,
-                s[5] & 0xf, (s[5] & 0x00f0) >> 4, (s[5] & 0x0f00) >> 8, (s[5] & 0xf000) >> 12,
-                s[4] & 0xf, (s[4] & 0x00f0) >> 4, (s[4] & 0x0f00) >> 8, (s[4] & 0xf000) >> 12,
-                s[3] & 0xf, (s[3] & 0x00f0) >> 4, (s[3] & 0x0f00) >> 8, (s[3] & 0xf000) >> 12,
-                s[2] & 0xf, (s[2] & 0x00f0) >> 4, (s[2] & 0x0f00) >> 8, (s[2] & 0xf000) >> 12,
-                s[1] & 0xf, (s[1] & 0x00f0) >> 4, (s[1] & 0x0f00) >> 8, (s[1] & 0xf000) >> 12,
-                s[0] & 0xf, (s[0] & 0x00f0) >> 4, (s[0] & 0x0f00) >> 8, (s[0] & 0xf000) >> 12)
+                s[7] & 0xf,
+                (s[7] & 0x00f0) >> 4,
+                (s[7] & 0x0f00) >> 8,
+                (s[7] & 0xf000) >> 12,
+                s[6] & 0xf,
+                (s[6] & 0x00f0) >> 4,
+                (s[6] & 0x0f00) >> 8,
+                (s[6] & 0xf000) >> 12,
+                s[5] & 0xf,
+                (s[5] & 0x00f0) >> 4,
+                (s[5] & 0x0f00) >> 8,
+                (s[5] & 0xf000) >> 12,
+                s[4] & 0xf,
+                (s[4] & 0x00f0) >> 4,
+                (s[4] & 0x0f00) >> 8,
+                (s[4] & 0xf000) >> 12,
+                s[3] & 0xf,
+                (s[3] & 0x00f0) >> 4,
+                (s[3] & 0x0f00) >> 8,
+                (s[3] & 0xf000) >> 12,
+                s[2] & 0xf,
+                (s[2] & 0x00f0) >> 4,
+                (s[2] & 0x0f00) >> 8,
+                (s[2] & 0xf000) >> 12,
+                s[1] & 0xf,
+                (s[1] & 0x00f0) >> 4,
+                (s[1] & 0x0f00) >> 8,
+                (s[1] & 0xf000) >> 12,
+                s[0] & 0xf,
+                (s[0] & 0x00f0) >> 4,
+                (s[0] & 0x0f00) >> 8,
+                (s[0] & 0xf000) >> 12
+            )
         }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use super::{address_equal, address_name};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn test_address_equal() {
@@ -63,15 +88,21 @@ mod test {
 
         assert!(address_equal(&a, &IpAddr::V6(ip.to_ipv6_compatible())));
         assert!(address_equal(&a, &IpAddr::V6(ip.to_ipv6_mapped())));
-        assert!(!address_equal(&a, &IpAddr::V6(
-            Ipv6Addr::new(1, 0, 0, 0, 0, 0, 0x0102, 0x0304))));
+        assert!(!address_equal(
+            &a,
+            &IpAddr::V6(Ipv6Addr::new(1, 0, 0, 0, 0, 0, 0x0102, 0x0304))
+        ));
     }
 
     #[test]
     fn test_address_name() {
-        assert_eq!(address_name(&"192.0.2.5".parse::<IpAddr>().unwrap()),
-            "5.2.0.192.in-addr.arpa");
-        assert_eq!(address_name(&"2001:db8::567:89ab".parse::<IpAddr>().unwrap()),
-            "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa");
+        assert_eq!(
+            address_name(&"192.0.2.5".parse::<IpAddr>().unwrap()),
+            "5.2.0.192.in-addr.arpa"
+        );
+        assert_eq!(
+            address_name(&"2001:db8::567:89ab".parse::<IpAddr>().unwrap()),
+            "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,8 @@ pub struct DnsConfig {
     pub timeout: Duration,
     /// Number of attempts made before returning an error
     pub attempts: u32,
-
+    /// Retry on any socket error.
+    pub retry_on_socket_error: bool,
     /// Whether to rotate through available nameservers
     pub rotate: bool,
     /// If `true`, perform `AAAA` queries first and return IPv4 addresses
@@ -35,14 +36,14 @@ impl DnsConfig {
     /// Returns a `DnsConfig` using the given set of name servers,
     /// setting all other fields to generally sensible default values.
     pub fn with_name_servers(name_servers: Vec<SocketAddr>) -> DnsConfig {
-        DnsConfig{
+        DnsConfig {
             name_servers: name_servers,
             search: Vec::new(),
 
             n_dots: 1,
             timeout: Duration::from_secs(5),
             attempts: 5,
-
+            retry_on_socket_error: false,
             rotate: false,
             use_inet6: false,
         }
@@ -59,5 +60,8 @@ fn default_config_impl() -> io::Result<DnsConfig> {
 fn default_config_impl() -> io::Result<DnsConfig> {
     // TODO: Get a list of nameservers from Windows API.
     // For now, return an IO error.
-    Err(io::Error::new(io::ErrorKind::Other, "Nameserver list not available on Windows"))
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        "Nameserver list not available on Windows",
+    ))
 }

--- a/src/hostname.rs
+++ b/src/hostname.rs
@@ -21,8 +21,7 @@ pub fn get_hostname() -> io::Result<String> {
             let s = unsafe { CStr::from_ptr(buf.as_ptr()) };
             match from_utf8(s.to_bytes()) {
                 Ok(s) => Ok(s.to_owned()),
-                Err(_) => Err(io::Error::new(
-                    io::ErrorKind::Other, "invalid hostname"))
+                Err(_) => Err(io::Error::new(io::ErrorKind::Other, "invalid hostname")),
             }
         }
     }

--- a/src/hosts.rs
+++ b/src/hosts.rs
@@ -38,8 +38,9 @@ impl HostTable {
     ///
     /// If no match is found, `None` is returned.
     pub fn find_host_by_name(&self, name: &str) -> Option<&Host> {
-        self.hosts.iter().find(|h| h.name == name ||
-            h.aliases.iter().any(|a| a == name))
+        self.hosts
+            .iter()
+            .find(|h| h.name == name || h.aliases.iter().any(|a| a == name))
     }
 }
 
@@ -72,7 +73,7 @@ fn host_file_impl() -> PathBuf {
         Some(root) => PathBuf::from(root).join("System32/drivers/etc/hosts"),
         // I'm not sure if this is the "correct" thing to do,
         // but it seems like a better alternative than panicking.
-        None => PathBuf::from("C:/Windows/System32/drivers/etc/hosts")
+        None => PathBuf::from("C:/Windows/System32/drivers/etc/hosts"),
     }
 }
 
@@ -103,29 +104,32 @@ pub fn parse_host_table(data: &str) -> io::Result<HostTable> {
 
         let addr_str = match words.next() {
             Some(w) => w,
-            None => continue
+            None => continue,
         };
 
         let addr = match addr_str.parse() {
             Ok(addr) => addr,
-            Err(_) => return Err(io::Error::new(io::ErrorKind::InvalidData,
-                format!("invalid address: {}", addr_str)))
+            Err(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid address: {}", addr_str),
+                ))
+            }
         };
 
         let name = match words.next() {
             Some(w) => w,
-            None => return Err(io::Error::new(io::ErrorKind::InvalidData,
-                "missing names"))
+            None => return Err(io::Error::new(io::ErrorKind::InvalidData, "missing names")),
         };
 
-        hosts.push(Host{
+        hosts.push(Host {
             address: addr,
             name: name.to_owned(),
             aliases: words.map(|s| s.to_owned()).collect(),
         });
     }
 
-    Ok(HostTable{hosts: hosts})
+    Ok(HostTable { hosts: hosts })
 }
 
 #[cfg(test)]
@@ -139,13 +143,16 @@ mod test {
 
     #[test]
     fn test_hosts() {
-        let hosts = parse_host_table("\
+        let hosts = parse_host_table(
+            "\
 # Comment line
 127.0.0.1       localhost
 ::1             ip6-localhost
 
 192.168.10.1    foo foo.bar foo.local # Mid-line comment
-").unwrap();
+",
+        )
+        .unwrap();
 
         assert_eq!(hosts.find_address("localhost"), Some(ip("127.0.0.1")));
         assert_eq!(hosts.find_address("ip6-localhost"), Some(ip("::1")));

--- a/src/idna.rs
+++ b/src/idna.rs
@@ -31,7 +31,7 @@ pub fn to_unicode(s: &str) -> Result<Cow<str>, Error> {
     if is_unicode {
         match external_idna::domain_to_unicode(s) {
             (s, Ok(_)) => Ok(Owned(s)),
-            (_, Err(_)) => Err(Error)
+            (_, Err(_)) => Err(Error),
         }
     } else {
         Ok(Borrowed(s))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,25 +4,26 @@
 
 extern crate idna as external_idna;
 extern crate libc;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 extern crate rand;
 
 pub use address::address_name;
 pub use config::DnsConfig;
 pub use idna::{to_ascii, to_unicode};
-pub use message::{DecodeError, EncodeError, Message, Question, Resource,
-    MESSAGE_LIMIT};
+pub use message::{DecodeError, EncodeError, Message, Question, Resource, MESSAGE_LIMIT};
 pub use record::{Class, Record, RecordType};
 pub use resolver::{resolve_addr, resolve_host, DnsResolver};
 pub use socket::{DnsSocket, Error};
 
 pub mod address;
 pub mod config;
-pub mod hosts;
 pub mod hostname;
+pub mod hosts;
 pub mod idna;
 pub mod message;
 pub mod record;
-#[cfg(unix)] pub mod resolv_conf;
+#[cfg(unix)]
+pub mod resolv_conf;
 pub mod resolver;
 pub mod socket;

--- a/src/record.rs
+++ b/src/record.rs
@@ -83,7 +83,7 @@ macro_rules! record_types {
     }
 }
 
-record_types!{
+record_types! {
     A => 1,
     AAAA => 28,
     CName => 5,
@@ -118,14 +118,18 @@ impl Record for A {
     fn decode(data: &mut MsgReader) -> Result<Self, DecodeError> {
         let mut buf = [0; 4];
         try!(data.read(&mut buf));
-        Ok(A{address: Ipv4Addr::new(buf[0], buf[1], buf[2], buf[3])})
+        Ok(A {
+            address: Ipv4Addr::new(buf[0], buf[1], buf[2], buf[3]),
+        })
     }
 
     fn encode(&self, data: &mut MsgWriter) -> Result<(), EncodeError> {
         data.write(&self.address.octets())
     }
 
-    fn record_type() -> RecordType { RecordType::A }
+    fn record_type() -> RecordType {
+        RecordType::A
+    }
 }
 
 /// An IPv6 host address
@@ -140,21 +144,32 @@ impl Record for AAAA {
         let mut buf = [0; 16];
         try!(data.read(&mut buf));
         let segments: [u16; 8] = unsafe { transmute(buf) };
-        Ok(AAAA{address: Ipv6Addr::new(
-            u16::from_be(segments[0]), u16::from_be(segments[1]),
-            u16::from_be(segments[2]), u16::from_be(segments[3]),
-            u16::from_be(segments[4]), u16::from_be(segments[5]),
-            u16::from_be(segments[6]), u16::from_be(segments[7]))})
+        Ok(AAAA {
+            address: Ipv6Addr::new(
+                u16::from_be(segments[0]),
+                u16::from_be(segments[1]),
+                u16::from_be(segments[2]),
+                u16::from_be(segments[3]),
+                u16::from_be(segments[4]),
+                u16::from_be(segments[5]),
+                u16::from_be(segments[6]),
+                u16::from_be(segments[7]),
+            ),
+        })
     }
 
     fn encode(&self, data: &mut MsgWriter) -> Result<(), EncodeError> {
         let mut segments = self.address.segments();
-        for seg in &mut segments { *seg = seg.to_be() }
+        for seg in &mut segments {
+            *seg = seg.to_be()
+        }
         let buf: [u8; 16] = unsafe { transmute(segments) };
         data.write(&buf)
     }
 
-    fn record_type() -> RecordType { RecordType::AAAA }
+    fn record_type() -> RecordType {
+        RecordType::AAAA
+    }
 }
 
 /// Canonical name for an alias
@@ -166,14 +181,18 @@ pub struct CName {
 
 impl Record for CName {
     fn decode(data: &mut MsgReader) -> Result<Self, DecodeError> {
-        Ok(CName{name: try!(data.read_name())})
+        Ok(CName {
+            name: try!(data.read_name()),
+        })
     }
 
     fn encode(&self, data: &mut MsgWriter) -> Result<(), EncodeError> {
         data.write_name(&self.name)
     }
 
-    fn record_type() -> RecordType { RecordType::CName }
+    fn record_type() -> RecordType {
+        RecordType::CName
+    }
 }
 
 /// Mail exchange data
@@ -188,7 +207,7 @@ pub struct Mx {
 
 impl Record for Mx {
     fn decode(data: &mut MsgReader) -> Result<Self, DecodeError> {
-        Ok(Mx{
+        Ok(Mx {
             preference: try!(data.read_u16()),
             exchange: try!(data.read_name()),
         })
@@ -199,7 +218,9 @@ impl Record for Mx {
         data.write_name(&self.exchange)
     }
 
-    fn record_type() -> RecordType { RecordType::Mx }
+    fn record_type() -> RecordType {
+        RecordType::Mx
+    }
 }
 
 /// Authoritative name server
@@ -211,14 +232,18 @@ pub struct Ns {
 
 impl Record for Ns {
     fn decode(data: &mut MsgReader) -> Result<Self, DecodeError> {
-        Ok(Ns{name: try!(data.read_name())})
+        Ok(Ns {
+            name: try!(data.read_name()),
+        })
     }
 
     fn encode(&self, data: &mut MsgWriter) -> Result<(), EncodeError> {
         data.write_name(&self.name)
     }
 
-    fn record_type() -> RecordType { RecordType::Ns }
+    fn record_type() -> RecordType {
+        RecordType::Ns
+    }
 }
 
 /// Domain name pointer
@@ -230,14 +255,18 @@ pub struct Ptr {
 
 impl Record for Ptr {
     fn decode(data: &mut MsgReader) -> Result<Self, DecodeError> {
-        Ok(Ptr{name: try!(data.read_name())})
+        Ok(Ptr {
+            name: try!(data.read_name()),
+        })
     }
 
     fn encode(&self, data: &mut MsgWriter) -> Result<(), EncodeError> {
         data.write_name(&self.name)
     }
 
-    fn record_type() -> RecordType { RecordType::Ptr }
+    fn record_type() -> RecordType {
+        RecordType::Ptr
+    }
 }
 
 /// Start of authority
@@ -265,7 +294,7 @@ pub struct Soa {
 
 impl Record for Soa {
     fn decode(data: &mut MsgReader) -> Result<Self, DecodeError> {
-        Ok(Soa{
+        Ok(Soa {
             mname: try!(data.read_name()),
             rname: try!(data.read_name()),
             serial: try!(data.read_u32()),
@@ -287,7 +316,9 @@ impl Record for Soa {
         Ok(())
     }
 
-    fn record_type() -> RecordType { RecordType::Soa }
+    fn record_type() -> RecordType {
+        RecordType::Soa
+    }
 }
 
 /// Service record
@@ -305,7 +336,7 @@ pub struct Srv {
 
 impl Record for Srv {
     fn decode(data: &mut MsgReader) -> Result<Self, DecodeError> {
-        Ok(Srv{
+        Ok(Srv {
             priority: try!(data.read_u16()),
             weight: try!(data.read_u16()),
             port: try!(data.read_u16()),
@@ -321,7 +352,9 @@ impl Record for Srv {
         Ok(())
     }
 
-    fn record_type() -> RecordType { RecordType::Srv }
+    fn record_type() -> RecordType {
+        RecordType::Srv
+    }
 }
 
 /// Text record
@@ -333,12 +366,16 @@ pub struct Txt {
 
 impl Record for Txt {
     fn decode(data: &mut MsgReader) -> Result<Self, DecodeError> {
-        Ok(Txt{data: try!(data.read_character_string())})
+        Ok(Txt {
+            data: try!(data.read_character_string()),
+        })
     }
 
     fn encode(&self, data: &mut MsgWriter) -> Result<(), EncodeError> {
         data.write_character_string(&self.data)
     }
 
-    fn record_type() -> RecordType { RecordType::Txt }
+    fn record_type() -> RecordType {
+        RecordType::Txt
+    }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -16,12 +16,14 @@ impl DnsSocket {
     /// Returns a `DnsSocket`, bound to an unspecified address.
     pub fn new() -> io::Result<DnsSocket> {
         DnsSocket::bind(&SocketAddr::new(
-            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), 0))
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+            0,
+        ))
     }
 
     /// Returns a `DnsSocket`, bound to the given address.
     pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<DnsSocket> {
-        Ok(DnsSocket{
+        Ok(DnsSocket {
             sock: try!(UdpSocket::bind(addr)),
         })
     }
@@ -32,8 +34,7 @@ impl DnsSocket {
     }
 
     /// Sends a message to the given address.
-    pub fn send_message<A: ToSocketAddrs>(&self,
-            message: &Message, addr: A) -> Result<(), Error> {
+    pub fn send_message<A: ToSocketAddrs>(&self, message: &Message, addr: A) -> Result<(), Error> {
         let mut buf = [0; MESSAGE_LIMIT];
         let data = try!(message.encode(&mut buf));
         try!(self.sock.send_to(data, addr));
@@ -44,8 +45,10 @@ impl DnsSocket {
     /// The given buffer is used to store and parse message data.
     ///
     /// The buffer should be exactly `MESSAGE_LIMIT` bytes in length.
-    pub fn recv_from<'buf>(&self, buf: &'buf mut [u8])
-            -> Result<(Message<'buf>, SocketAddr), Error> {
+    pub fn recv_from<'buf>(
+        &self,
+        buf: &'buf mut [u8],
+    ) -> Result<(Message<'buf>, SocketAddr), Error> {
         let (n, addr) = try!(self.sock.recv_from(buf));
 
         let msg = try!(Message::decode(&buf[..n]));
@@ -57,8 +60,11 @@ impl DnsSocket {
     /// address, the message is not decoded and `Ok(None)` is returned.
     ///
     /// The buffer should be exactly `MESSAGE_LIMIT` bytes in length.
-    pub fn recv_message<'buf>(&self, addr: &SocketAddr, buf: &'buf mut [u8])
-            -> Result<Option<Message<'buf>>, Error> {
+    pub fn recv_message<'buf>(
+        &self,
+        addr: &SocketAddr,
+        buf: &'buf mut [u8],
+    ) -> Result<Option<Message<'buf>>, Error> {
         let (n, recv_addr) = try!(self.sock.recv_from(buf));
 
         if !socket_address_equal(&recv_addr, addr) {
@@ -89,10 +95,9 @@ impl Error {
         match *self {
             Error::IoError(ref e) => {
                 let kind = e.kind();
-                kind == io::ErrorKind::TimedOut ||
-                    kind == io::ErrorKind::WouldBlock
+                kind == io::ErrorKind::TimedOut || kind == io::ErrorKind::WouldBlock
             }
-            _ => false
+            _ => false,
         }
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -22,7 +22,8 @@ impl DnsSocket {
     }
 
     /// Returns a `DnsSocket`, bound to the given address.
-    pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<DnsSocket> {
+    pub fn bind<A: ToSocketAddrs + std::fmt::Debug>(addr: A) -> io::Result<DnsSocket> {
+        info!("Binding new DNS socket: {:?}", addr);
         Ok(DnsSocket {
             sock: try!(UdpSocket::bind(addr)),
         })


### PR DESCRIPTION
The only one real change is `retry_on_socket_error` flag in DnsConfig.
My idea was to allow retry on any error during resolving from dns. 

Example of problem:
On my Windows machine, if i using wrong dns for primary server i cannot resolve a hostname.
The same problem are appeared under firewall, when first dns was blocked by firewall, and system dns was used only as fallback. 


Also this patch contain rustfmt. If you need i can revert rustfmt, or apply it in separate commit.
